### PR TITLE
homework2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,14 +47,13 @@ jobs:
         pytest tests/test_data.py -v
 
     # --- Model Testing and Metrics ---
-    - name: Download previous model metrics
-      if: github.event_name == 'pull_request'
+    - name: Download previous model metrics (for PRs, if base branch is main/master)
+      if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master')
       uses: actions/download-artifact@v4
       with:
-        name: model-metrics-${{ github.base_ref }} # または 'model-metrics-master' など固定名
-        path: ./previous_metrics_artifact
-        # merge-multiple: false # シングルアーティファクトなら不要なことが多い
-      continue-on-error: true # 前のアーティファクトがない場合でも続行  
+        name: model-metrics-${{ github.base_ref }} # ブランチ固有のアーティファクト名 (main または master)
+        path: ./previous_metrics_artifact # ダウンロード先のフォルダ (リポジトリルート直下)
+      continue-on-error: true # アーティファクトがなくてもエラーにしない
 
     - name: Run model training and tests (generates current_metrics.json)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,14 @@ jobs:
         pytest tests/test_data.py -v
 
     # --- Model Testing and Metrics ---
-    - name: Download previous model metrics (for PRs, if base branch is main/master)
-      if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master')
+    - name: Download previous model metrics
+      if: github.event_name == 'pull_request'
       uses: actions/download-artifact@v4
       with:
-        name: model-metrics-${{ github.base_ref }} # ブランチ固有のアーティファクト名 (main または master)
-        path: ./previous_metrics_artifact # ダウンロード先のフォルダ (リポジトリルート直下)
-      continue-on-error: true # アーティファクトがなくてもエラーにしない
+        name: model-metrics-${{ github.base_ref }} # または 'model-metrics-master' など固定名
+        path: ./previous_metrics_artifact
+        # merge-multiple: false # シングルアーティファクトなら不要なことが多い
+      continue-on-error: true # 前のアーティファクトがない場合でも続行  
 
     - name: Run model training and tests (generates current_metrics.json)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,33 @@ jobs:
     # --- Model Testing and Metrics ---
     - name: Download previous model metrics (for PRs, if base branch is main/master)
       if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master')
-      uses: actions/download-artifact@v4
-      with:
-        name: model-metrics-${{ github.base_ref }} # ブランチ固有のアーティファクト名 (main または master)
-        path: ./previous_metrics_artifact # ダウンロード先のフォルダ (リポジトリルート直下)
-      continue-on-error: true # アーティファクトがなくてもエラーにしない
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub CLIがAPIを叩くために必要です
+        TARGET_BRANCH: ${{ github.base_ref }}
+      run: |
+        echo "Attempting to download metrics for branch: $TARGET_BRANCH"
+        LATEST_SUCCESSFUL_RUN_ID=$(gh run list --workflow "${{ github.workflow_id }}" --branch "$TARGET_BRANCH" --status success --limit 1 --json databaseId -q '.[0].databaseId')
+
+        if [ -z "$LATEST_SUCCESSFUL_RUN_ID" ] || [ "$LATEST_SUCCESSFUL_RUN_ID" == "null" ]; then
+          echo "No successful run found on branch '$TARGET_BRANCH' for workflow '${{ github.workflow_id }}'. Skipping download."
+          # continue-on-error: true の代わりのような振る舞いのため、ここでエラー終了しない
+          # この後のテストで previous_metrics_artifact が存在しないことを考慮する必要がある
+        else
+          echo "Found latest successful run ID on branch '$TARGET_BRANCH': $LATEST_SUCCESSFUL_RUN_ID"
+          echo "Downloading artifact: model-metrics-$TARGET_BRANCH from run ID: $LATEST_SUCCESSFUL_RUN_ID"
+          gh run download "$LATEST_SUCCESSFUL_RUN_ID" -R "${{ github.repository }}" -n "model-metrics-$TARGET_BRANCH" --dir ./previous_metrics_artifact
+          # ダウンロード成功したかを確認するためにファイル存在チェックをしても良い
+          if [ -f "./previous_metrics_artifact/current_metrics.json" ]; then # アップロード時のファイル名が current_metrics.json の場合
+            echo "Artifact downloaded successfully."
+          else
+            echo "Artifact download seems to have failed or the expected file is not present."
+            # ここで失敗扱いにするか、テスト側で処理するか
+          fi
+        fi
+      # このステップ全体をエラーで止めないようにするには、ステップに continue-on-error: true を追加します。
+      # ただし、スクリプト内でエラーハンドリングしているので、なくても良いかもしれません。
+      # 必要に応じて調整してください。
+      continue-on-error: true
 
     - name: Run model training and tests (generates current_metrics.json)
       run: |

--- a/day5/演習1/main.py
+++ b/day5/演習1/main.py
@@ -41,7 +41,7 @@ def prepare_data(test_size=0.2, random_state=42):
 
 # 学習と評価
 def train_and_evaluate(
-    X_train, X_test, y_train, y_test, n_estimators=100, max_depth=None, random_state=42
+    X_train, X_test, y_train, y_test, n_estimators=150, max_depth=None, random_state=42
 ):
     model = RandomForestClassifier(
         n_estimators=n_estimators, max_depth=max_depth, random_state=random_state

--- a/day5/演習3/tests/test_model.py
+++ b/day5/演習3/tests/test_model.py
@@ -27,16 +27,16 @@ warnings.filterwarnings("ignore", category=FutureWarning, module="sklearn")
 # メトリクスファイルはリポジトリルート直下に current_metrics.json として保存する想定
 BASE_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)  # リポジトリルート
+)  # このBASE_DIRの定義は、今回のメトリクスパス修正には直接使われませんが、他のパスで利用されている可能性を考慮し残します。
 DATA_PATH = os.path.join(os.path.dirname(__file__), "../data/Titanic.csv")
 MODEL_DIR = os.path.join(os.path.dirname(__file__), "../models")
 MODEL_PATH = os.path.join(MODEL_DIR, "titanic_model.pkl")
 
 # メトリクスファイルのパス (リポジトリのルート直下に保存/参照する想定)
-CURRENT_METRICS_PATH = os.path.join(BASE_DIR, "current_metrics.json")
+CURRENT_METRICS_PATH = "current_metrics.json"  # ★修正点：リポジトリルートからの相対パス
 # GitHub Actionsでダウンロードされた過去のメトリクスファイルへのパス
 # (ワークフローの download-artifact の path とアーティファクト名に合わせる)
-PREVIOUS_METRICS_ARTIFACT_DIR = os.path.join(BASE_DIR, "previous_metrics_artifact")
+PREVIOUS_METRICS_ARTIFACT_DIR = "previous_metrics_artifact"  # ★修正点：リポジトリルートからの相対パス
 PREVIOUS_METRICS_PATH = os.path.join(
     PREVIOUS_METRICS_ARTIFACT_DIR, "current_metrics.json"
 )  # アップロード時と同じファイル名
@@ -309,7 +309,7 @@ def test_performance_regression():
     )
 
     print(
-        f"性能比較 - 精度:      現在={current_accuracy:.4f}, 過去={previous_accuracy:.4f if previous_accuracy else 'N/A'}"
+        f"性能比較 - 精度:       現在={current_accuracy:.4f}, 過去={previous_accuracy:.4f if previous_accuracy else 'N/A'}"
     )
     print(
         f"性能比較 - 平均推論時間: 現在={current_inference_time_avg:.4f}ms, 過去={previous_inference_time_avg:.4f if previous_inference_time_avg else 'N/A'}ms"

--- a/day5/演習3/tests/test_model.py
+++ b/day5/演習3/tests/test_model.py
@@ -36,7 +36,9 @@ MODEL_PATH = os.path.join(MODEL_DIR, "titanic_model.pkl")
 CURRENT_METRICS_PATH = "current_metrics.json"  # ★修正点：リポジトリルートからの相対パス
 # GitHub Actionsでダウンロードされた過去のメトリクスファイルへのパス
 # (ワークフローの download-artifact の path とアーティファクト名に合わせる)
-PREVIOUS_METRICS_ARTIFACT_DIR = "previous_metrics_artifact"  # ★修正点：リポジトリルートからの相対パス
+PREVIOUS_METRICS_ARTIFACT_DIR = (
+    "previous_metrics_artifact"  # ★修正点：リポジトリルートからの相対パス
+)
 PREVIOUS_METRICS_PATH = os.path.join(
     PREVIOUS_METRICS_ARTIFACT_DIR, "current_metrics.json"
 )  # アップロード時と同じファイル名


### PR DESCRIPTION
- モデルメトリクスのダウンロードステップを簡素化し、条件を明確化
- CIワークフローでのモデルメトリクスのダウンロード条件を明確化し、デフォルトのn_estimatorsを150に変更
- モデルメトリクスのダウンロード処理を改善し、成功した最新の実行からアーティファクトを取得するロジックを追加
- メトリクスファイルのパスをリポジトリルートからの相対パスに修正し、BASE_DIRのコメントを更新
- メトリクスファイルのパスをリポジトリルートからの相対パスに修正し、コードの可読性を向上
